### PR TITLE
add information to flea market confirmation mail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'kbh'
-version = '1.0.14'
+version = '1.0.15'
 sourceCompatibility = '17'
 
 repositories {
@@ -30,7 +30,7 @@ dependencies {
 	implementation 'org.webjars:bootstrap:5.2.3'
 	implementation 'org.webjars:webjars-locator:0.46'
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
-
+	implementation 'com.sun.mail:jakarta.mail:2.0.1'
 
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

--- a/src/main/java/kbh/foerdervereinkita/service/impl/EMailServiceImpl.java
+++ b/src/main/java/kbh/foerdervereinkita/service/impl/EMailServiceImpl.java
@@ -48,6 +48,8 @@ public class EMailServiceImpl implements EMailService {
           in der Turnhalle der Grundschule Sonnenfeld Homburg
         statt.
 
+        Beachten Sie, dass wir ausschließlich Stellplätze zur Verfügung stellen, d.h. Tische o.ä. müssen selbst mitgebracht werden.
+
         Aufbau ist ab 11 Uhr möglich.
 
         Bitte überweisen Sie die Standgebühr in Höhe von 10 EUR (7 EUR mit Kuchen) pro 3m Stand im Voraus auf unser Konto:


### PR DESCRIPTION
Add remark to confirmation e-mail that we only offer storing positions at the flea market, i.e., tables or something similar have to be brought along.