### PR TITLE
extend flea market

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ buildNumber.properties
 /src/main/resources/static/images
 
 /src/main/resources/application-prod.yml
+
+# env file
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'kbh'
-version = '1.0.16'
+version = '1.0.17'
 sourceCompatibility = '17'
 
 repositories {

--- a/docker-compose/sql/setup.sql
+++ b/docker-compose/sql/setup.sql
@@ -49,3 +49,11 @@ CREATE TABLE IF NOT EXISTS `foerderverein`.`event_registrations`
     `comment`                TEXT,
     `registration_timestamp` TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS `foerderverein`.`storing_position`
+(
+    `id`                    INT    NOT NULL PRIMARY KEY,
+    `number`                INT    NOT NULL,
+    `event_registration_id` BIGINT NOT NULL,
+    CONSTRAINT `fk_storing_position_event_registration_id` FOREIGN KEY (`event_registration_id`) REFERENCES `foerderverein`.`event_registrations` (`id`)
+) DEFAULT CHARSET = utf8;

--- a/src/main/java/kbh/foerdervereinkita/auth/SecurityConfiguration.java
+++ b/src/main/java/kbh/foerdervereinkita/auth/SecurityConfiguration.java
@@ -48,7 +48,9 @@ public class SecurityConfiguration {
             "/board",
             "/webjars/**",
             "/images/**",
-            "/event-registrations")
+            "/event-registrations",
+            "/flohmarkt/**",
+            "/error")
         .permitAll()
         .and()
         .formLogin()

--- a/src/main/java/kbh/foerdervereinkita/dto/MyFleaMarketDto.java
+++ b/src/main/java/kbh/foerdervereinkita/dto/MyFleaMarketDto.java
@@ -1,0 +1,4 @@
+package kbh.foerdervereinkita.dto;
+
+public record MyFleaMarketDto(
+    String fullName, String email, boolean hasPaid, Integer storingPositionNumber) {}

--- a/src/main/java/kbh/foerdervereinkita/mapper/MyFleaMarketMapper.java
+++ b/src/main/java/kbh/foerdervereinkita/mapper/MyFleaMarketMapper.java
@@ -1,0 +1,26 @@
+package kbh.foerdervereinkita.mapper;
+
+import jakarta.transaction.Transactional;
+import kbh.foerdervereinkita.dto.MyFleaMarketDto;
+import kbh.foerdervereinkita.mvc.form.MyRegistrationForm;
+import kbh.foerdervereinkita.storage.model.EventRegistrationEntity;
+import kbh.foerdervereinkita.storage.model.StoringPositionEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MyFleaMarketMapper {
+
+  @Mapping(target = "hasPaid", ignore = true)
+  @Mapping(target = "storingPositionNumber", ignore = true)
+  @Mapping(target = "fullName", ignore = true)
+  MyFleaMarketDto toDto(MyRegistrationForm form);
+
+  @Transactional
+  @Mapping(target = "fullName", source = "eventRegistration.fullName")
+  @Mapping(target = "email", source = "eventRegistration.email")
+  @Mapping(target = "hasPaid", expression = "java(eventRegistration.getFeeValuationDate() != null)")
+  @Mapping(target = "storingPositionNumber", source = "storingPosition.number")
+  MyFleaMarketDto toDto(
+      EventRegistrationEntity eventRegistration, StoringPositionEntity storingPosition);
+}

--- a/src/main/java/kbh/foerdervereinkita/mvc/controller/FleaMarketController.java
+++ b/src/main/java/kbh/foerdervereinkita/mvc/controller/FleaMarketController.java
@@ -22,29 +22,39 @@ import org.springframework.web.servlet.view.RedirectView;
 
 @Controller
 @RequiredArgsConstructor
-public class EventRegistrationController {
+public class FleaMarketController {
   private final Config config;
   private final EventRegistrationService service;
   private final EventRegistrationMapper mapper;
 
+  @GetMapping(path = "/flohmarkt")
+  ModelAndView fleaMarketGet() {
+    return new ModelAndView("flea-market");
+  }
+
   @GetMapping(path = "/event-registrations")
-  ModelAndView eventRegistrationGet(Model model) {
+  RedirectView eventRegistrationGet() {
+    return new RedirectView("/flohmarkt/anmeldung", true);
+  }
+
+  @GetMapping(path = "/flohmarkt/anmeldung")
+  ModelAndView fleaMarketRegistrationGet(Model model) {
 
     model.addAttribute("eventRegistrationForm", new EventRegistrationForm());
     model.addAttribute("registrationVacanciesCount", service.registrationVacanciesCount());
 
-    return new ModelAndView("event-registration");
+    return new ModelAndView("flea-market-registration");
   }
 
-  @PostMapping(path = "/event-registrations")
-  ModelAndView eventRegistrationPost(
+  @PostMapping(path = "/flohmarkt/anmeldung")
+  ModelAndView fleaMarketRegistrationPost(
       @Validated(ValidationSequence.class) @ModelAttribute("eventRegistrationForm")
           EventRegistrationForm form,
       BindingResult bindingResult,
       RedirectAttributes redirectAttributes) {
 
     if (bindingResult.hasErrors()) {
-      return new ModelAndView("event-registration");
+      return new ModelAndView("flea-market-registration");
     }
 
     EventRegistrationDto eventRegistration = mapper.toDto(form);
@@ -55,7 +65,7 @@ public class EventRegistrationController {
 
     redirectAttributes.addFlashAttribute("success", successMessage);
 
-    return new ModelAndView(new RedirectView("/event-registrations", true));
+    return new ModelAndView(new RedirectView("/flohmarkt/anmeldung", true));
   }
 
   @GetMapping(path = "/internal/event-registrations")

--- a/src/main/java/kbh/foerdervereinkita/mvc/controller/MyFleaMarketController.java
+++ b/src/main/java/kbh/foerdervereinkita/mvc/controller/MyFleaMarketController.java
@@ -1,0 +1,53 @@
+package kbh.foerdervereinkita.mvc.controller;
+
+import java.awt.*;
+import kbh.foerdervereinkita.dto.MyFleaMarketDto;
+import kbh.foerdervereinkita.mapper.MyFleaMarketMapper;
+import kbh.foerdervereinkita.mvc.form.MyRegistrationForm;
+import kbh.foerdervereinkita.service.MyFleaMarketService;
+import kbh.foerdervereinkita.validate.ValidationSequence;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@AllArgsConstructor
+public class MyFleaMarketController {
+
+  private MyFleaMarketService service;
+  private MyFleaMarketMapper mapper;
+
+  @GetMapping(path = "/flohmarkt/meine-anmeldung")
+  ModelAndView fleaMarketMyRegistrationGet(Model model) {
+
+    model.addAttribute("myRegistrationForm", new MyRegistrationForm());
+
+    return new ModelAndView("my-registration");
+  }
+
+  @PostMapping(path = "/flohmarkt/meine-anmeldung")
+  ModelAndView fleaMarketMyRegistrationPost(
+      @Validated(ValidationSequence.class) @ModelAttribute("myRegistrationForm")
+          MyRegistrationForm form,
+      BindingResult bindingResult,
+      Model model) {
+
+    if (bindingResult.hasErrors()) {
+      return new ModelAndView("my-registration");
+    }
+
+    MyFleaMarketDto myFleaMarketRequest = mapper.toDto(form);
+
+    MyFleaMarketDto myFleaMarketResponse = service.fetch(myFleaMarketRequest);
+
+    model.addAttribute("myFleaMarket", myFleaMarketResponse);
+
+    return new ModelAndView("my-registration-state");
+  }
+}

--- a/src/main/java/kbh/foerdervereinkita/mvc/form/MyRegistrationForm.java
+++ b/src/main/java/kbh/foerdervereinkita/mvc/form/MyRegistrationForm.java
@@ -1,0 +1,17 @@
+package kbh.foerdervereinkita.mvc.form;
+
+import jakarta.validation.constraints.NotEmpty;
+import kbh.foerdervereinkita.validate.ExistingEMail;
+import kbh.foerdervereinkita.validate.FirstValidation;
+import kbh.foerdervereinkita.validate.SecondValidation;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MyRegistrationForm {
+
+  @NotEmpty(groups = FirstValidation.class)
+  @ExistingEMail(groups = SecondValidation.class)
+  private String email;
+}

--- a/src/main/java/kbh/foerdervereinkita/mvc/model/MyRegistrationModel.java
+++ b/src/main/java/kbh/foerdervereinkita/mvc/model/MyRegistrationModel.java
@@ -1,0 +1,3 @@
+package kbh.foerdervereinkita.mvc.model;
+
+public class MyRegistrationModel {}

--- a/src/main/java/kbh/foerdervereinkita/service/MyFleaMarketService.java
+++ b/src/main/java/kbh/foerdervereinkita/service/MyFleaMarketService.java
@@ -1,0 +1,8 @@
+package kbh.foerdervereinkita.service;
+
+import kbh.foerdervereinkita.dto.MyFleaMarketDto;
+
+public interface MyFleaMarketService {
+
+  MyFleaMarketDto fetch(MyFleaMarketDto myFleaMarket);
+}

--- a/src/main/java/kbh/foerdervereinkita/service/impl/MyFleaMarketServiceImpl.java
+++ b/src/main/java/kbh/foerdervereinkita/service/impl/MyFleaMarketServiceImpl.java
@@ -1,0 +1,32 @@
+package kbh.foerdervereinkita.service.impl;
+
+import kbh.foerdervereinkita.dto.MyFleaMarketDto;
+import kbh.foerdervereinkita.mapper.MyFleaMarketMapper;
+import kbh.foerdervereinkita.service.MyFleaMarketService;
+import kbh.foerdervereinkita.storage.model.EventRegistrationEntity;
+import kbh.foerdervereinkita.storage.model.StoringPositionEntity;
+import kbh.foerdervereinkita.storage.repository.EventRegistrationRepository;
+import kbh.foerdervereinkita.storage.repository.StoringPositionRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+class MyFleaMarketServiceImpl implements MyFleaMarketService {
+
+  private EventRegistrationRepository eventRegistrationRepository;
+  private StoringPositionRepository storingPositionRepository;
+  private MyFleaMarketMapper mapper;
+
+  @Override
+  public MyFleaMarketDto fetch(MyFleaMarketDto myFleaMarket) {
+
+    EventRegistrationEntity eventRegistration =
+        eventRegistrationRepository.findByEmail(myFleaMarket.email());
+
+    StoringPositionEntity storingPosition =
+        storingPositionRepository.findByEventRegistration_Email(myFleaMarket.email()).orElse(null);
+
+    return mapper.toDto(eventRegistration, storingPosition);
+  }
+}

--- a/src/main/java/kbh/foerdervereinkita/storage/model/StoringPositionEntity.java
+++ b/src/main/java/kbh/foerdervereinkita/storage/model/StoringPositionEntity.java
@@ -1,0 +1,25 @@
+package kbh.foerdervereinkita.storage.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "storing_position")
+public class StoringPositionEntity {
+  @Id
+  @Column(name = "id", nullable = false)
+  private Integer id;
+
+  @NotNull
+  @Column(name = "number", nullable = false)
+  private Integer number;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "event_registration_id", nullable = false)
+  private EventRegistrationEntity eventRegistration;
+}

--- a/src/main/java/kbh/foerdervereinkita/storage/repository/EventRegistrationRepository.java
+++ b/src/main/java/kbh/foerdervereinkita/storage/repository/EventRegistrationRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRegistrationRepository extends JpaRepository<EventRegistrationEntity, Long> {
   boolean existsByEmail(String eMail);
+
+  EventRegistrationEntity findByEmail(String email);
 }

--- a/src/main/java/kbh/foerdervereinkita/storage/repository/StoringPositionRepository.java
+++ b/src/main/java/kbh/foerdervereinkita/storage/repository/StoringPositionRepository.java
@@ -1,0 +1,10 @@
+package kbh.foerdervereinkita.storage.repository;
+
+import kbh.foerdervereinkita.storage.model.StoringPositionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface StoringPositionRepository extends JpaRepository<StoringPositionEntity, Long> {
+
+  Optional<StoringPositionEntity> findByEventRegistration_Email(String email);
+}

--- a/src/main/java/kbh/foerdervereinkita/validate/ExistingEMail.java
+++ b/src/main/java/kbh/foerdervereinkita/validate/ExistingEMail.java
@@ -1,0 +1,18 @@
+package kbh.foerdervereinkita.validate;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ExistingEMailValidator.class)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistingEMail {
+
+  String message() default "Es existiert keine Anmeldung mit dieser E-Mail Adresse.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kbh/foerdervereinkita/validate/ExistingEMailValidator.java
+++ b/src/main/java/kbh/foerdervereinkita/validate/ExistingEMailValidator.java
@@ -1,0 +1,32 @@
+package kbh.foerdervereinkita.validate;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kbh.foerdervereinkita.service.EventRegistrationService;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ExistingEMailValidator implements ConstraintValidator<ExistingEMail, String> {
+
+  private EventRegistrationService service;
+
+  @Override
+  public void initialize(ExistingEMail constraintAnnotation) {
+    // intentionally left empty
+  }
+
+  @Override
+  public boolean isValid(String email, ConstraintValidatorContext context) {
+
+    if (service.exists(email)) {
+      return true;
+    }
+
+    context
+        .buildConstraintViolationWithTemplate(
+            "Es existiert keine Anmeldung mit dieser E-Mail Adresse.")
+        .addConstraintViolation();
+
+    return false;
+  }
+}

--- a/src/main/resources/templates/flea-market-registration.html
+++ b/src/main/resources/templates/flea-market-registration.html
@@ -41,7 +41,7 @@
         <div class="alert alert-info my-2 text-center" role="alert" th:if="${success}" th:utext="${success}"></div>
     </div>
     <div class="container">
-        <form action="#" style="..." th:action="@{/event-registrations}" th:method="POST"
+        <form action="#" style="..." th:action="@{/flohmarkt/anmeldung}" th:method="POST"
               th:object="${eventRegistrationForm}">
             <div class="my-2">
                 <input type="text" class="form-control" placeholder="Name" th:field="*{fullName}">

--- a/src/main/resources/templates/flea-market.html
+++ b/src/main/resources/templates/flea-market.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <title>Flohmarkt</title>
+    <meta name="format-detection" content="telephone=no">
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="container">
+        <div class="row justify-content-between">
+
+            <div class="col-5">
+                <img src="#" th:src="@{~/images/flohmarktPoster2023Web.jpeg}" class="card-img" alt="...">
+            </div>
+            <div class="col-5 align-self-center">
+                <div class="row justify-content-center">
+                    <div class="col-12 justify-content-center">
+                        <button class="btn btn-info btn-lg my-4">
+                            <a class="link-dark fw-bold" th:href="@{/flohmarkt/anmeldung}">Anmelden</a>
+                        </button>
+                    </div>
+                    <div class="col-12 justify-content-center">
+                        <button class="btn btn-info btn-lg my-4">
+                            <a class="link-dark fw-bold" th:href="@{/flohmarkt/meine-anmeldung}">Meine Anmeldung</a>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -21,7 +21,7 @@
                 </button>
                 </br>
                 <button class="btn btn-info btn-lg my-4">
-                    <a class="link-dark fw-bold" th:href="@{/event-registrations}">!!! Flohmarktanmeldung !!!</a>
+                    <a class="link-dark fw-bold" th:href="@{/flohmarkt}">!!! Flohmarkt !!!</a>
                 </button>
             </div>
             <div class="col-md align-items-center my-3">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -22,6 +22,9 @@
         <div class="collapse navbar-collapse" id="navmenu">
             <ul class="navbar-nav ms-auto">
                 <li sec:authorize="!isAuthenticated()" class="nav-item">
+                    <a href="#" th:href="@{/flohmarkt}" class="nav-link">Flohmarkt</a>
+                </li>
+                <li sec:authorize="!isAuthenticated()" class="nav-item">
                     <a href="#" th:href="@{/events}" class="nav-link">Veranstaltungen</a>
                 </li>
                 <li sec:authorize="!isAuthenticated()" class="nav-item">

--- a/src/main/resources/templates/my-registration-state.html
+++ b/src/main/resources/templates/my-registration-state.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <title>Meine Anmeldung</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="container">
+        <div class="text-center my-2">
+            <span style="font-size: large;font-weight: bold" th:text="'Hallo ' + ${myFleaMarket.fullName()}"></span>
+        </div>
+        <div class="text-center my-2">
+            <span style="font-size: large">Schön, dass Sie an unserem Flohmarkt teilnehmen.</span>
+        </div>
+        <div th:if="${myFleaMarket.hasPaid()}" class="alert alert-info my-4 text-center">
+            <span style="font-size: large">Die Standgebühr ist überwiesen.</span>
+        </div>
+        <div th:unless="${myFleaMarket.hasPaid()}" class="alert alert-warning my-4 text-center">
+            Leider wurde die Standgebühr bisher nicht überwiesen.
+        </div>
+        <div th:if="${myFleaMarket.storingPositionNumber()}" class="alert alert-info my-4 text-center">
+            <span style="font-size: large"
+                  th:text="'Ihre Standnummer ist ' + ${myFleaMarket.storingPositionNumber()} + '.'"></span>
+        </div>
+        <div th:unless="${myFleaMarket.storingPositionNumber()}" class="alert alert-warning my-4 text-center">
+            <span>Ihre Standnummer ist noch nicht vergeben.</span>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/my-registration.html
+++ b/src/main/resources/templates/my-registration.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <title>Meine Anmeldung</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="container my-2">
+        <div class="text-center my-2">
+            <span style="font-size: large;font-weight: bold">Schauen Sie nach Ihrer Flohmarktanmeldung.</span>
+        </div>
+        <div class="text-center my-2">
+            <span>Einfach die E-Mail eingeben, mit der Sie sich registriert haben.</span>
+        </div>
+    </div>
+    <div class="container w-75 my-4">
+        <form action="#" style="..." th:action="@{/flohmarkt/meine-anmeldung}" th:method="POST"
+              th:object="${myRegistrationForm}">
+            <div class="my-2">
+                <input type="email" class="form-control" placeholder="E-Mail" th:field="*{email}">
+                <p th:if="${#fields.hasErrors('email')}" th:errors="*{email}"
+                   class="alert alert-warning my-2 text-center"></p>
+            </div>
+            <div class="my-4">
+                <input type="submit" value="Meine Anmeldung">
+            </div>
+        </form>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Add flea market to menu. Allow to see own registration progress, i.e., if fee has been received and the number given to the storing position. Moreover, add the poster to the flea market page.