### PR TITLE
FV-43 enhance fetching image list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 apply from: 'gradle/spotless.gradle'
 
 group = 'kbh'
-version = '1.6.0'
+version = '1.7.0'
 
 java {
     sourceCompatibility = '21'

--- a/src/main/java/kbh/foerdervereinkita/media/MediaFileMapper.java
+++ b/src/main/java/kbh/foerdervereinkita/media/MediaFileMapper.java
@@ -5,6 +5,7 @@ import java.security.InvalidKeyException;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import kbh.foerdervereinkita.storage.model.MediaFileEntity;
+import kbh.foerdervereinkita.storage.model.MediaFileProjection;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -21,7 +22,7 @@ public abstract class MediaFileMapper {
 
   @Mapping(target = "id", source = "id")
   @Mapping(target = "fileName", source = "fileName")
-  abstract MediaFileDTO toDTO(MediaFileEntity entity);
+  abstract MediaFileDTO toDTO(MediaFileProjection projection);
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "fileName", expression = "java(file.getOriginalFilename())")

--- a/src/main/java/kbh/foerdervereinkita/media/MediaFileService.java
+++ b/src/main/java/kbh/foerdervereinkita/media/MediaFileService.java
@@ -21,7 +21,7 @@ public class MediaFileService {
   private final FileSecurity fileSecurity;
 
   public List<MediaFileDTO> fetchAll() {
-    return repository.findAll().stream().map(mapper::toDTO).toList();
+    return repository.findAllProjectedBy().stream().map(mapper::toDTO).toList();
   }
 
   public Resource fetch(long id) {

--- a/src/main/java/kbh/foerdervereinkita/storage/model/MediaFileProjection.java
+++ b/src/main/java/kbh/foerdervereinkita/storage/model/MediaFileProjection.java
@@ -1,0 +1,7 @@
+package kbh.foerdervereinkita.storage.model;
+
+public interface MediaFileProjection {
+    Long getId();
+
+    String getFileName();
+}

--- a/src/main/java/kbh/foerdervereinkita/storage/repository/MediaFileRepository.java
+++ b/src/main/java/kbh/foerdervereinkita/storage/repository/MediaFileRepository.java
@@ -1,9 +1,12 @@
 package kbh.foerdervereinkita.storage.repository;
 
+import java.util.Collection;
 import kbh.foerdervereinkita.storage.model.MediaFileEntity;
+import kbh.foerdervereinkita.storage.model.MediaFileProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MediaFileRepository extends JpaRepository<MediaFileEntity, Long> {
+  Collection<MediaFileProjection> findAllProjectedBy();
 
   MediaFileEntity findById(long id);
 


### PR DESCRIPTION
Issue
When going to the image overview, the site loading is very slow. This is due to fact, that all images have been loaded from the databse.

Enhancement
Loading all images is not necessary, since only the name and database id is required. As such, a JPA projection "cuts" only the id and filename from the JPA entity in order to speed up loading.